### PR TITLE
Add `-hevring-preview` flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,16 +18,17 @@ import (
 )
 
 var (
-	imgPath      = flag.String("image", "", "Filepath of an image to flut")
-	ránAddr      = flag.String("rán", "", "Start RPC server to distribute jobs, listening on the given address/port")
-	hevringAddr  = flag.String("hevring", "", "Connect to PRC server at given address/port")
-	address      = flag.String("host", ":1234", "Target server address")
-	connections  = flag.Int("connections", 4, "Number of simultaneous connections. Each connection posts a subimage")
-	x            = flag.Int("x", 0, "Offset of posted image from left border")
-	y            = flag.Int("y", 0, "Offset of posted image from top border")
-	order        = flag.String("order", "rtl", "Draw order (shuffle, ltr, rtl, ttb, btt)")
-	fetchImgPath = flag.String("fetch", "", "Enable fetching the screen area to the given local file, updating it each second")
-	cpuprofile   = flag.String("cpuprofile", "", "Destination file for CPU Profile")
+	imgPath        = flag.String("image", "", "Filepath of an image to flut")
+	ránAddr        = flag.String("rán", "", "Start RPC server to distribute jobs, listening on the given address/port")
+	hevringAddr    = flag.String("hevring", "", "Connect to RPC server at given address/port")
+	address        = flag.String("host", ":1234", "Target server address")
+	connections    = flag.Int("connections", 4, "Number of simultaneous connections. Each connection posts a subimage")
+	x              = flag.Int("x", 0, "Offset of posted image from left border")
+	y              = flag.Int("y", 0, "Offset of posted image from top border")
+	order          = flag.String("order", "rtl", "Draw order (shuffle, ltr, rtl, ttb, btt)")
+	fetchImgPath   = flag.String("fetch", "", "Enable fetching the screen area to the given local file, updating it each second")
+	hevringImgPath = flag.String("hevring-preview", "", "Write the current task image to the given PNG file")
+	cpuprofile     = flag.String("cpuprofile", "", "Destination file for CPU Profile")
 )
 
 func main() {
@@ -83,7 +84,8 @@ func taskFromFlags(stop chan bool, wg *sync.WaitGroup) {
 	}
 
 	if startClient {
-		rpc.ConnectHevring(hev, stop, wg)
+		hevring := rpc.ConnectHevring(hev, stop, wg)
+		hevring.PreviewPath = *hevringImgPath
 	}
 
 	if fetchImg {

--- a/rpc/dottir.go
+++ b/rpc/dottir.go
@@ -25,6 +25,18 @@ func ConnectHevring(ránAddress string, stop chan bool, wg *sync.WaitGroup) *Hev
 	go rpc.ServeConn(conn)
 	fmt.Printf("[hevring] awaiting task from Rán\n")
 
+	// print performance
+	go func() {
+		for {
+			time.Sleep(5 * time.Second)
+			if pixelflut.PerformanceReporter.Enabled {
+				fmt.Println(pixelflut.PerformanceReporter)
+			}
+		}
+	}()
+
+	// add listener to stop the task, if this hevring should stop
+	// (either because Rán told us so, or we received an interrupt)
 	h.quit = stop
 	h.wg = wg
 	h.wg.Add(1)
@@ -44,8 +56,8 @@ func ConnectHevring(ránAddress string, stop chan bool, wg *sync.WaitGroup) *Hev
 type Hevring struct {
 	PreviewPath string
 	task        pixelflut.FlutTask
-	taskQuit    chan bool
-	quit        chan bool
+	taskQuit    chan bool // if closed, task is stopped.
+	quit        chan bool // if closed, kills this hevring
 	wg          *sync.WaitGroup
 }
 


### PR DESCRIPTION
- If `-hevring-preview` is enabled, Hevring stores the current task image to the given path. (fix #6)
- Hevring prints performance metrics once enabled by Rán.