### PR TITLE
REPL improvements

### DIFF
--- a/render/text.go
+++ b/render/text.go
@@ -16,7 +16,7 @@ func pt(p fixed.Point26_6) image.Point {
 	}
 }
 
-func RenderText(text string, scale int, texture, bgTex image.Image) *image.NRGBA {
+func RenderText(text string, scale float64, texture, bgTex image.Image) *image.NRGBA {
 	face := basicfont.Face7x13
 	stringBounds, _ := font.BoundString(face, text)
 
@@ -38,5 +38,5 @@ func RenderText(text string, scale int, texture, bgTex image.Image) *image.NRGBA
 	img.Rect = img.Bounds().Sub(img.Bounds().Min)
 
 	// scale up, as this font is quite small
-	return ScaleImage(img, scale)
+	return ScaleImage(img, scale, scale, false)
 }

--- a/rpc/repl.go
+++ b/rpc/repl.go
@@ -31,6 +31,7 @@ func RunREPL(f Fluter) {
 	textSize := 10.0
 	var textCol image.Image = image.White
 	var bgCol image.Image = image.Transparent
+	var taskStore = make(map[string]pixelflut.FlutTask)
 
 	fmt.Print("[rán] REPL is active. ")
 	printHelp()
@@ -71,6 +72,22 @@ func RunREPL(f Fluter) {
 				if t.Paused {
 					f.stopTask()
 					printTask = false
+				}
+
+			case "store", "save":
+				printTask = false
+				if len(args) == 0 {
+					fmt.Println("must specify name")
+				} else {
+					taskStore[strings.Join(args, " ")] = t
+				}
+				continue
+
+			case "load", "l":
+				if len(args) == 0 {
+					fmt.Println("must specify name")
+				} else {
+					t = taskStore[strings.Join(args, " ")]
 				}
 
 			case "offset", "of":
@@ -195,10 +212,12 @@ func RunREPL(f Fluter) {
 
 func printHelp() {
 	fmt.Println(`available commands:
-	general
+	tasks
 		start                                start fluting
 		stop                                 pause fluting
 		status                               print current task
+		save <name>                          store current task
+		load <name>							 load previously stored task
 	content
 		i <filepath>                         set image
 		txt <scale> <color <bgcolor> <txt>   send text

--- a/rpc/repl.go
+++ b/rpc/repl.go
@@ -86,7 +86,7 @@ func RunREPL(f Fluter) {
 					}
 				}
 
-			case "address", "a":
+			case "host", "address", "a":
 				if len(args) == 1 {
 					t.Address = args[0]
 				}
@@ -131,14 +131,24 @@ func RunREPL(f Fluter) {
 					}
 				}
 
+			// the commands below don't affect the task, so we don't need to apply it to clients -> continue
+
 			case "metrics":
 				f.toggleMetrics()
-				printTask = false
+				continue
+
+			case "status":
+				fmt.Println(t)
+				continue
+
+			case "help":
+				printHelp()
+				continue
 
 			default:
-				printTask = false
 				fmt.Print("[rán] unknown command. ")
 				printHelp()
+				continue
 			}
 
 			if printTask {
@@ -151,18 +161,18 @@ func RunREPL(f Fluter) {
 
 func printHelp() {
 	fmt.Println(`available commands:
-	start                                start fluting
-	stop                                 pause fluting
+		start                                start fluting
+		stop                                 pause fluting
 	c <n>                                set number of connections per client
 	a <host>:<port>                      set target server
 	offset <x> <y>                       set top-left offset
 	offset rand                          random offset for each draw
 	metrics                              toggle bandwidth reporting (may cost some performance)
 
-	i <filepath>                         set image
-	txt <scale> <color <bgcolor> <txt>   send text
-	txt [<scale> [<color> [<bgcolor>]]   enter interactive text mode
-	rgbsplit                             toggle RGB split effect
+		i <filepath>                         set image
+		txt <scale> <color <bgcolor> <txt>   send text
+		txt [<scale> [<color> [<bgcolor>]]   enter interactive text mode
+		rgbsplit                             toggle RGB split effect
 	o                                    set order (l,r,t,b,shuffle)`)
 }
 

--- a/rpc/repl.go
+++ b/rpc/repl.go
@@ -28,7 +28,7 @@ const textMode = "txt"
 // RunREPL starts reading os.Stdin for commands to apply to the given Fluter
 func RunREPL(f Fluter) {
 	mode := commandMode
-	textSize := 10
+	textSize := 10.0
 	var textCol image.Image = image.White
 	var bgCol image.Image = image.Transparent
 
@@ -109,7 +109,7 @@ func RunREPL(f Fluter) {
 			case "txt":
 				if len(args) > 0 {
 					if size, err := strconv.Atoi(args[0]); err == nil {
-						textSize = size
+						textSize = float64(size)
 					}
 				}
 				if len(args) > 1 {
@@ -137,6 +137,33 @@ func RunREPL(f Fluter) {
 						t.Img = img
 					}
 				}
+
+			case "scale", "s":
+				quality := true
+				var facX, facY float64
+				var err error
+				if len(args) >= 1 {
+					facX, err = strconv.ParseFloat(args[0], 64)
+					if err != nil {
+						fmt.Println(err)
+						continue
+					}
+					facY = facX
+					if len(args) >= 2 {
+						facY, err = strconv.ParseFloat(args[1], 64)
+						if err != nil {
+							fmt.Println(err)
+							continue
+						}
+					}
+					if len(args) > 2 {
+						quality = false
+					}
+					t.Img = render.ScaleImage(t.Img, facX, facY, quality)
+				}
+
+			case "rotate", "r":
+				t.Img = render.RotateImage90(t.Img)
 
 			// the commands below don't affect the task, so we don't need to apply it to clients -> continue
 
@@ -176,6 +203,8 @@ func printHelp() {
 		i <filepath>                         set image
 		txt <scale> <color <bgcolor> <txt>   send text
 		txt [<scale> [<color> [<bgcolor>]]   enter interactive text mode
+		scale <facX> [<facY> [lofi]]         scale content
+		rotate                               rotate content 90°
 	draw modes
 		o                                    set order (l,r,t,b,random)
 		of <x> <y>                           set top-left offset

--- a/rpc/repl.go
+++ b/rpc/repl.go
@@ -161,19 +161,23 @@ func RunREPL(f Fluter) {
 
 func printHelp() {
 	fmt.Println(`available commands:
+	general
 		start                                start fluting
 		stop                                 pause fluting
-	c <n>                                set number of connections per client
-	a <host>:<port>                      set target server
-	offset <x> <y>                       set top-left offset
-	offset rand                          random offset for each draw
-	metrics                              toggle bandwidth reporting (may cost some performance)
-
+		status                               print current task
+	content
 		i <filepath>                         set image
 		txt <scale> <color <bgcolor> <txt>   send text
 		txt [<scale> [<color> [<bgcolor>]]   enter interactive text mode
+	draw modes
+		o                                    set order (l,r,t,b,random)
+		of <x> <y>                           set top-left offset
+		of rand                              random offset for each draw
 		rgbsplit                             toggle RGB split effect
-	o                                    set order (l,r,t,b,shuffle)`)
+	networking
+		c <n>                                set number of connections per client
+		a <host>:<port>                      set target server
+		metrics                              toggle bandwidth reporting (may cost some performance)`)
 }
 
 // try to parse as hex-encoded RGB color,

--- a/rpc/repl.go
+++ b/rpc/repl.go
@@ -66,6 +66,13 @@ func RunREPL(f Fluter) {
 			case "start":
 				t.Paused = false
 
+			case "toggle", ".":
+				t.Paused = !t.Paused
+				if t.Paused {
+					f.stopTask()
+					printTask = false
+				}
+
 			case "offset", "of":
 				if len(args) == 1 && args[0] == "rand" {
 					t.RandOffset = true


### PR DESCRIPTION
#### fixes
- don't reissue task to clients for unrelated actions (eg toggle metrics,  print status, display help

#### new commands
- `save`, `load`: quick switching between different tasks by naming them
- `scale` & `rotate`. (rotate is really simple, only 90° CW) (fixes #4)
- `status`, `help`, `toggle`
